### PR TITLE
Extending PMM’s Prometheus Configuration

### DIFF
--- a/helm/pmm-server/README.md
+++ b/helm/pmm-server/README.md
@@ -44,6 +44,7 @@ The following tables lists the configurable parameters of the Percona chart and 
 | `resources`                | CPU/Memory resource requests/limits | Memory: `1Gi`, CPU: `0.5`                                  |
 | `service.type`             | Option specifying the [Kubernetes Service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) to be used | ""                                                         |
 | `service.loadBalancerIP`   | IP address for the public access    | ""                                                         |
+| `prometheus.configMap.name`   | Name of k8s configMap with scrape_configs    | ""                                                         |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. 

--- a/helm/pmm-server/templates/statefulset.yaml
+++ b/helm/pmm-server/templates/statefulset.yaml
@@ -41,6 +41,11 @@ spec:
           volumeMounts:
             - name: pmmdata
               mountPath: /pmmdata
+{{ if .Values.prometheus.configMap.name }}              
+            - name: prometheus-configmap
+              mountPath: /srv/prometheus/prometheus.base.yml
+              subPath: prometheus.base.yml
+{{ end }}            
 
           env:
             - name: DISABLE_UPDATES
@@ -119,6 +124,14 @@ spec:
 {{ end }}
 
               bash -x /opt/entrypoint.sh
+
+{{ if .Values.prometheus.configMap.name }}              
+      volumes:
+      - name: prometheus-configmap
+        configMap:
+          name: {{ .Values.prometheus.configMap.name }}
+{{ end }}
+
       {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:

--- a/helm/pmm-server/values.yaml
+++ b/helm/pmm-server/values.yaml
@@ -43,3 +43,8 @@ resources:
 service:
   type: LoadBalancer
   loadBalancerIP: ""
+
+## Mount prometheus scrape config https://www.percona.com/blog/2020/03/23/extending-pmm-prometheus-configuration/
+prometheus:
+  configMap:
+    name: ""

--- a/helm/pmm-server/values.yaml
+++ b/helm/pmm-server/values.yaml
@@ -2,7 +2,7 @@
 ## ref: https://hub.docker.com/r/library/percona/tags/
 ##
 imageRepo: "percona/pmm-server"
-imageTag: "2.3.0"
+imageTag: "2.4.0"
 
 ## A choice between "kubernetes" and "openshift"
 platform: "openshift"


### PR DESCRIPTION
 Mount prometheus scrape config  as in https://www.percona.com/blog/2020/03/23/extending-pmm-prometheus-configuration/
PMM ver: 2.4