### PR TITLE
CLOUD-589 Pass additional Statefulset labels and any Annotations from values.yaml

### DIFF
--- a/helm/pmm-server/README.md
+++ b/helm/pmm-server/README.md
@@ -47,6 +47,8 @@ The following tables lists the configurable parameters of the Percona chart and 
 | `prometheus.configMap.name`   | Name of k8s configMap with scrape_configs    | ""                                                         |
 | `statefulSet.labels`       | Additional labels for the statefulset    | ""                                                    |
 | `statefulSet.annotations`  | Annotations for the statefulset     | ""                                                         |
+| `podTemplate.labels`       | Additional labels to be passed to the underlying Pod    | ""                                                    |
+| `podTemplate.annotations`  | Annotations for the Pod     | ""                                                         |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. 

--- a/helm/pmm-server/README.md
+++ b/helm/pmm-server/README.md
@@ -47,8 +47,8 @@ The following tables lists the configurable parameters of the Percona chart and 
 | `prometheus.configMap.name`   | Name of k8s configMap with scrape_configs    | ""                                                         |
 | `statefulSet.labels`       | Additional labels for the statefulset    | ""                                                    |
 | `statefulSet.annotations`  | Annotations for the statefulset     | ""                                                         |
-| `podTemplate.labels`       | Additional labels to be passed to the underlying Pod    | ""                                                    |
-| `podTemplate.annotations`  | Annotations for the Pod     | ""                                                         |
+| `statefulSet.podTemplate.labels`       | Additional labels to be passed to the underlying Pod    | ""                                                    |
+| `statefulSet.podTemplate.annotations`  | Annotations for the Pod     | ""                                                         |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. 

--- a/helm/pmm-server/README.md
+++ b/helm/pmm-server/README.md
@@ -45,6 +45,8 @@ The following tables lists the configurable parameters of the Percona chart and 
 | `service.type`             | Option specifying the [Kubernetes Service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) to be used | ""                                                         |
 | `service.loadBalancerIP`   | IP address for the public access    | ""                                                         |
 | `prometheus.configMap.name`   | Name of k8s configMap with scrape_configs    | ""                                                         |
+| `statefulSet.labels`       | Additional labels for the statefulset    | ""                                                    |
+| `statefulSet.annotations`  | Annotations for the statefulset     | ""                                                         |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. 

--- a/helm/pmm-server/templates/statefulset.yaml
+++ b/helm/pmm-server/templates/statefulset.yaml
@@ -7,6 +7,13 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- if .Values.statefulSet.labels }}
+{{ toYaml .Values.statefulSet.labels | indent 4 }}
+{{- end }}
+  {{- with .Values.statefulSet.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
 spec:
   serviceName: {{ template "percona.fullname" . }}
   replicas: 1

--- a/helm/pmm-server/templates/statefulset.yaml
+++ b/helm/pmm-server/templates/statefulset.yaml
@@ -28,6 +28,13 @@ spec:
       labels:
         app: {{ template "percona.fullname" . }}
         component: pmm
+{{- if .Values.podTemplate.labels }}
+{{ toYaml .Values.podTemplate.labels | indent 8 }}
+{{- end }}
+{{- with .Values.podTemplate.annotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+{{- end }}
     spec:
       securityContext:
         supplementalGroups: [1000]

--- a/helm/pmm-server/templates/statefulset.yaml
+++ b/helm/pmm-server/templates/statefulset.yaml
@@ -28,10 +28,10 @@ spec:
       labels:
         app: {{ template "percona.fullname" . }}
         component: pmm
-{{- if .Values.podTemplate.labels }}
+{{- if .Values.statefulSet.podTemplate.labels }}
 {{ toYaml .Values.podTemplate.labels | indent 8 }}
 {{- end }}
-{{- with .Values.podTemplate.annotations }}
+{{- with .Values.statefulSet.podTemplate.annotations }}
       annotations:
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/helm/pmm-server/templates/statefulset.yaml
+++ b/helm/pmm-server/templates/statefulset.yaml
@@ -10,10 +10,10 @@ metadata:
 {{- if .Values.statefulSet.labels }}
 {{ toYaml .Values.statefulSet.labels | indent 4 }}
 {{- end }}
-  {{- with .Values.statefulSet.annotations }}
+{{- with .Values.statefulSet.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
-  {{- end }}
+{{- end }}
 spec:
   serviceName: {{ template "percona.fullname" . }}
   replicas: 1

--- a/helm/pmm-server/templates/statefulset.yaml
+++ b/helm/pmm-server/templates/statefulset.yaml
@@ -29,7 +29,7 @@ spec:
         app: {{ template "percona.fullname" . }}
         component: pmm
 {{- if .Values.statefulSet.podTemplate.labels }}
-{{ toYaml .Values.podTemplate.labels | indent 8 }}
+{{ toYaml .Values.statefulSet.podTemplate.labels | indent 8 }}
 {{- end }}
 {{- with .Values.statefulSet.podTemplate.annotations }}
       annotations:

--- a/helm/pmm-server/values.yaml
+++ b/helm/pmm-server/values.yaml
@@ -59,3 +59,8 @@ prometheus:
 statefulSet:
   annotations: {}
   labels: {}
+
+## Set Pod Labels and Annotations
+podTemplate:
+  annotations: {}
+  labels: {}

--- a/helm/pmm-server/values.yaml
+++ b/helm/pmm-server/values.yaml
@@ -54,3 +54,8 @@ service:
 prometheus:
   configMap:
     name: ""
+
+## Pass Statefulset Annotations
+statefulSet:
+  annotations: {}
+  labels: {}

--- a/helm/pmm-server/values.yaml
+++ b/helm/pmm-server/values.yaml
@@ -59,8 +59,7 @@ prometheus:
 statefulSet:
   annotations: {}
   labels: {}
-
-## Set Pod Labels and Annotations
-podTemplate:
-  annotations: {}
-  labels: {}
+  ## Set Pod Labels and Annotations
+  podTemplate:
+    annotations: {}
+    labels: {}

--- a/helm/pmm-server/values.yaml
+++ b/helm/pmm-server/values.yaml
@@ -55,7 +55,7 @@ prometheus:
   configMap:
     name: ""
 
-## Pass Statefulset Annotations
+## Set Statefulset Labels and Annotations
 statefulSet:
   annotations: {}
   labels: {}


### PR DESCRIPTION
This addition to the statefulset template and values file allows custom
labels to be passed into the metadata labels block AND annotations.

Our usecase for annotations is to set our vault providers
(vault.security.banzaicloud.io) vault-role for permission to get
any secretes required (in this case, credentials.password)

CLOUD-589