### PR TITLE
K8SPSMDB-338 Allow non-default scc usage

### DIFF
--- a/helm/pmm-server/Chart.yaml
+++ b/helm/pmm-server/Chart.yaml
@@ -1,5 +1,5 @@
 name: pmm-server
-version: 2.12.0
+version: 2.12.1
 description: Percona Monitoring and Management (PMM) is an open-source platform for managing and monitoring MySQL and MongoDB performance.
 keywords:
 - mysql

--- a/helm/pmm-server/templates/statefulset.yaml
+++ b/helm/pmm-server/templates/statefulset.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   serviceName: {{ template "percona.fullname" . }}
   replicas: 1
-  updateStrategy: 
+  updateStrategy:
     type: RollingUpdate
   selector:
     matchLabels:
@@ -18,15 +18,18 @@ spec:
       component: pmm
   template:
     metadata:
+      {{ if eq .Values.platform "openshift" }}
+      annotations:
+        openshift.io/scc: {{ .Values.scc | default "privileged" }}
+      {{ end }}
       labels:
         app: {{ template "percona.fullname" . }}
         component: pmm
     spec:
+      serviceAccountName: {{ .Values.sa | default "default" }}
       securityContext:
         supplementalGroups: [1000]
-{{ if eq .Values.platform "kubernetes" }}
         fsGroup: 1000
-{{ end }}
       containers:
         - name: {{ template "percona.fullname" . }}
           image: "{{ .Values.imageRepo }}:{{ .Values.imageTag }}"
@@ -41,11 +44,11 @@ spec:
           volumeMounts:
             - name: pmmdata
               mountPath: /pmmdata
-{{ if .Values.prometheus.configMap.name }}              
+{{ if .Values.prometheus.configMap.name }}
             - name: prometheus-configmap
               mountPath: /srv/prometheus/prometheus.base.yml
               subPath: prometheus.base.yml
-{{ end }}            
+{{ end }}
 
           env:
             - name: DISABLE_UPDATES
@@ -128,7 +131,7 @@ spec:
 
               bash -x /opt/entrypoint.sh
 
-{{ if .Values.prometheus.configMap.name }}              
+{{ if .Values.prometheus.configMap.name }}
       volumes:
       - name: prometheus-configmap
         configMap:

--- a/helm/pmm-server/templates/svc.yaml
+++ b/helm/pmm-server/templates/svc.yaml
@@ -17,5 +17,5 @@ spec:
   selector:
     component: pmm
     app: {{ template "percona.fullname" . }}
-  type: {{ .Values.service.type | quote }}
+  type: {{ .Values.service.type | default "LoadBalancer" | quote }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP | quote }}

--- a/helm/pmm-server/values.yaml
+++ b/helm/pmm-server/values.yaml
@@ -12,7 +12,8 @@ platform: "kubernetes"
 ## ref: http://kubernetes.io/docs/user-guide/images/#updating-images
 ##
 imagePullPolicy: Always
-
+scc: null
+sa: null
 ## Persist data to a persitent volume
 persistence:
   enabled: true
@@ -47,7 +48,7 @@ resources:
     cpu: 0.5
 
 service:
-  type: LoadBalancer
+  type: null
   loadBalancerIP: ""
 
 ## Mount prometheus scrape config https://www.percona.com/blog/2020/03/23/extending-pmm-prometheus-configuration/


### PR DESCRIPTION
Since the current version of pmm-server requires elevated
privileges, the user should be able to pass settings to chart

``helm install monitoring --set platform=openshift --set sa=percona-server-mongodb-operator``