### PR TITLE
Allow usage with helm3

### DIFF
--- a/helm/pmm-server/Chart.yaml
+++ b/helm/pmm-server/Chart.yaml
@@ -1,3 +1,4 @@
+apiVersion: v2
 name: pmm-server
 version: 2.12.3
 description: Percona Monitoring and Management (PMM) is an open-source platform for managing and monitoring MySQL and MongoDB performance.


### PR DESCRIPTION
When I tried to use the chart, found it was not deployable via helm3.

According https://helm.sh/docs/topics/charts/  apiVersion: field is required, minor semantic issue